### PR TITLE
Find a way to optionally apply add multiplatform config.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,13 +86,13 @@ jobs:
           java-version: 11
 
       - name: Performance Tests - Warm Up
-        run: ./gradlew check -Pkmp4free=false -Pkmp4free.ios=false -Pkmp4free.js=false--rerun-tasks --stacktrace --scan
+        run: ./gradlew check -Pkmp4free=false -Pios=false -Pjs=false--rerun-tasks --stacktrace --scan
 
       - name: Performance Tests - jvm kmp4free disabled
-        run: ./gradlew :samples:jvm_kmp4free:assemble -Pkmp4free=false -Pkmp4free.ios=false -Pkmp4free.js=false -Pperftest=:samples:jvm_kmp4free --rerun-tasks --stacktrace --scan
+        run: ./gradlew :samples:jvm_kmp4free:assemble -Pkmp4free=false -Pios=false -Pjs=false -Pperftest=:samples:jvm_kmp4free --rerun-tasks --stacktrace --scan
 
       - name: Performance Tests - multiplatform kmp4free disabled
-        run: ./gradlew :samples:multiplatform_kmp4free:assemble -Pkmp4free=false -Pkmp4free.ios=false -Pkmp4free.js=false -Pperftest=:samples:multiplatform_kmp4free --stacktrace --scan
+        run: ./gradlew :samples:multiplatform_kmp4free:assemble -Pkmp4free=false -Pios=false -Pjs=false -Pperftest=:samples:multiplatform_kmp4free --stacktrace --scan
 
   perf-kmp4free-enabled:
     runs-on: ubuntu-latest
@@ -110,13 +110,13 @@ jobs:
           java-version: 11
 
       - name: Performance Tests - Warm Up
-        run: ./gradlew check -Pkmp4free=true -Pkmp4free.ios=false -Pkmp4free.js=false--rerun-tasks --stacktrace --scan
+        run: ./gradlew check -Pkmp4free=true -Pios=false -Pjs=false--rerun-tasks --stacktrace --scan
 
       - name: Performance Tests - jvm kmp4free enabled
-        run: ./gradlew :samples:jvm_kmp4free:assemble -Pkmp4free=true -Pkmp4free.ios=false -Pkmp4free.js=false -Pperftest=:samples:jvm_kmp4free --rerun-tasks --stacktrace --scan
+        run: ./gradlew :samples:jvm_kmp4free:assemble -Pkmp4free=true -Pios=false -Pjs=false -Pperftest=:samples:jvm_kmp4free --rerun-tasks --stacktrace --scan
 
       - name: Performance Tests - multiplatform kmp4free enabled
-        run: ./gradlew :samples:multiplatform_kmp4free:assemble -Pkmp4free=true -Pkmp4free.ios=false -Pkmp4free.js=false -Pperftest=:samples:multiplatform_kmp4free --rerun-tasks --stacktrace --scan
+        run: ./gradlew :samples:multiplatform_kmp4free:assemble -Pkmp4free=true -Pios=false -Pjs=false -Pperftest=:samples:multiplatform_kmp4free --rerun-tasks --stacktrace --scan
 
 
   publish:

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,3 @@ kotlin.mpp.enableCInteropCommonization=true
 
 # KMP4FREE
 kmp4free=false
-kmp4free.ios=true
-kmp4free.js=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ kotlin.mpp.enableCInteropCommonization=true
 
 # KMP4FREE
 kmp4free=false
+
+# KMP Targets
+ios=false
+js=false

--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/Kmp4FreePlugin.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/Kmp4FreePlugin.kt
@@ -10,8 +10,10 @@ import org.gradle.api.Project
  */
 public class Kmp4FreePlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        val isMultiplatformEnabled = Kmp4FreePropertyValues(target).isMultiplatformEnabled
+
         val kmp4FreeMagic = Kmp4FreeMagic(target)
-        if (Kmp4FreePropertyValues(target).isMultiplatformEnabled) {
+        if (isMultiplatformEnabled) {
             // Use Kotlin Multiplatform Plugin
             println("Applying Plugin org.jetbrains.kotlin.multiplatform to ${target.path}")
             target.plugins.apply("org.jetbrains.kotlin.multiplatform")
@@ -22,5 +24,6 @@ public class Kmp4FreePlugin : Plugin<Project> {
             target.plugins.apply("org.jetbrains.kotlin.jvm")
             kmp4FreeMagic.enableKotlinJvm()
         }
+
     }
 }

--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeMagic.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeMagic.kt
@@ -8,30 +8,12 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
  */
 internal class Kmp4FreeMagic(private val target: Project) {
 
-    private val gradleProperties = Kmp4FreePropertyValues(target)
-
     fun enableKotlinMultiplatform() {
         val multiplatformExtension =
             target.extensions.getByType(KotlinMultiplatformExtension::class.java)
         multiplatformExtension.apply {
             // Always enable JVM
-            jvm {
-                withJava()
-            }
-            if (gradleProperties.isIosEnabled) {
-                println("Enabling iOS Multiplatform Target for ${target.path}")
-                multiplatformExtension.apply {
-//                    iosX64()
-//                    iosArm64()
-                    iosSimulatorArm64()
-                }
-            }
-            if (gradleProperties.isJsEnabled) {
-                println("Enabling JavaScript Multiplatform Target for ${target.path}")
-                multiplatformExtension.js(IR) {
-                    browser()
-                }
-            }
+            jvm()
         }
 
         // Extend Configurations and SourceSets

--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreePropertyValues.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreePropertyValues.kt
@@ -6,24 +6,13 @@ import org.gradle.api.Project
  * Helpers to access relevant Gradle properties in a clean way
  */
 internal class Kmp4FreePropertyValues(private val project: Project) {
+
     val isMultiplatformEnabled: Boolean
         get() {
             return project.findProperty(GRADLE_PROPERTY_MULTIPLATFORM) == "true"
         }
 
-    val isJsEnabled: Boolean
-        get() {
-            return project.findProperty(GRADLE_PROPERTY_JS) == "true"
-        }
-
-    val isIosEnabled: Boolean
-        get() {
-            return project.findProperty(GRADLE_PROPERTY_IOS) == "true"
-        }
-
     companion object {
         const val GRADLE_PROPERTY_MULTIPLATFORM = "kmp4free"
-        const val GRADLE_PROPERTY_JS = "kmp4free.js"
-        const val GRADLE_PROPERTY_IOS = "kmp4free.ios"
     }
 }

--- a/samples/jvm_kmp4free/build.gradle.kts
+++ b/samples/jvm_kmp4free/build.gradle.kts
@@ -11,11 +11,16 @@ dependencies {
 project.extensions.findByType(
     org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
 )?.apply {
-    listOf(
-        iosSimulatorArm64()
-    ).forEach { nativeTarget ->
-        nativeTarget.binaries.framework {
-            baseName = "jvm_kmp4free"
+    if (project.findProperty("ios") == "true") {
+        iosSimulatorArm64 {
+            binaries.framework {
+                baseName = project.name
+            }
+        }
+    }
+    if (project.findProperty("js") == "true") {
+        js(IR) {
+            browser()
         }
     }
 }

--- a/samples/jvm_kmp4free/build.gradle.kts
+++ b/samples/jvm_kmp4free/build.gradle.kts
@@ -1,9 +1,21 @@
 plugins {
-  id("com.handstandsam.kmp4free")
+    id("com.handstandsam.kmp4free")
 }
 
 dependencies {
-  implementation(libs.kotlin.stdlib)
-  testImplementation(libs.kotlin.test.common)
-  testImplementation(libs.truth)
+    implementation(libs.kotlin.stdlib)
+    testImplementation(libs.kotlin.test.common)
+    testImplementation(libs.truth)
+}
+
+project.extensions.findByType(
+    org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java
+)?.apply {
+    listOf(
+        iosSimulatorArm64()
+    ).forEach { nativeTarget ->
+        nativeTarget.binaries.framework {
+            baseName = "jvm_kmp4free"
+        }
+    }
 }


### PR DESCRIPTION
Tried to figure out an elegant solution to https://github.com/handstandsam/kmp4free/issues/2

It didn't make sense for `kmp4free` to be opinionated about what multiplatform targets you should use or support.  This method allows you to have full control over that, and then it is outside the scope of this plugin.