### PR TITLE
Add resources support

### DIFF
--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
@@ -34,10 +34,17 @@ internal class Kmp4FreeSourceSetMagic(
             listOf(
                 "src/$extendsFromSourceSetName/java",
                 "src/$extendsFromSourceSetName/kotlin",
-                "src/$extendsFromSourceSetName/resources",
             ).forEach {
                 kotlin.srcDir(it)
                 logger.info("Added $it as a srcDir for $sourceSetName")
+            }
+            logger.info("--------")
+
+            listOf(
+                "src/$extendsFromSourceSetName/resources",
+            ).forEach {
+                resources.srcDir(it)
+                logger.info("Added $it as resources for $sourceSetName")
             }
             logger.info("--------")
         }


### PR DESCRIPTION
## Summary

This PR adds JVM `resources` support by configuring the `resources` property of each `KotlinSourceSet` rather than adding that to the `kotlin` property
---
Fixes #15 