### PR TITLE
Support JAR Resources in jvmMain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,5 +30,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kmp4free=false
 
 # KMP Targets
-ios=true
+ios=false
 js=false

--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
@@ -3,6 +3,7 @@ package com.handstandsam.kmp4free.internal
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.configurationcache.extensions.capitalized
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -19,6 +20,9 @@ internal class Kmp4FreeSourceSetMagic(
 
     private val kotlinProjectExtension: KotlinProjectExtension =
         target.extensions.getByType(KotlinProjectExtension::class.java)
+
+    private val javaPluginExtension: JavaPluginExtension =
+        target.extensions.getByType(JavaPluginExtension::class.java)
 
     private val sourceSets: NamedDomainObjectContainer<KotlinSourceSet> =
         kotlinProjectExtension.sourceSets
@@ -37,6 +41,9 @@ internal class Kmp4FreeSourceSetMagic(
             ).forEach {
                 kotlin.srcDir(it)
                 logger.info("Added $it as a srcDir for $sourceSetName")
+            }
+            javaPluginExtension.sourceSets.forEach {
+                it.resources.srcDir("src/$extendsFromSourceSetName/resources")
             }
             logger.info("--------")
 

--- a/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
+++ b/kmp4free/src/main/kotlin/com/handstandsam/kmp4free/internal/Kmp4FreeSourceSetMagic.kt
@@ -3,7 +3,6 @@ package com.handstandsam.kmp4free.internal
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.configurationcache.extensions.capitalized
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -20,9 +19,6 @@ internal class Kmp4FreeSourceSetMagic(
 
     private val kotlinProjectExtension: KotlinProjectExtension =
         target.extensions.getByType(KotlinProjectExtension::class.java)
-
-    private val javaPluginExtension: JavaPluginExtension =
-        target.extensions.getByType(JavaPluginExtension::class.java)
 
     private val sourceSets: NamedDomainObjectContainer<KotlinSourceSet> =
         kotlinProjectExtension.sourceSets
@@ -41,9 +37,6 @@ internal class Kmp4FreeSourceSetMagic(
             ).forEach {
                 kotlin.srcDir(it)
                 logger.info("Added $it as a srcDir for $sourceSetName")
-            }
-            javaPluginExtension.sourceSets.forEach {
-                it.resources.srcDir("src/$extendsFromSourceSetName/resources")
             }
             logger.info("--------")
 

--- a/samples/jvm_kmp4free/src/jvmMain/resources/META-INF/proguard/kotlinx-serialization.pro
+++ b/samples/jvm_kmp4free/src/jvmMain/resources/META-INF/proguard/kotlinx-serialization.pro
@@ -1,0 +1,33 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault


### PR DESCRIPTION
Thank you @jonamireh for identifying [the issue](https://github.com/handstandsam/kmp4free/issues/15), and providing the reproduction case.  It made it easy to figure out.  Also thanks for #13 to fix this.  After this fix, it worked when building with `kmp4free=true`, but did not work with `kmp4free=false`, so this diff fixes that support when it is disabled and additionally adds in a sample file so I could could test.

You can see in the debugging lines below, but we need to add it to the `javaPluginExtension` as well to see the debug output: `Added src/jvmMain/resources as Java resources for main` where it maps correctly when kmp4free is disabled.

----

Fix: We didn't have the support to include `resources` in the source directory of your `src/jvmMain` folder.  This PR fixes that.

## `kmp4free=false`
<img width="670" alt="Screen Shot 2022-09-14 at 8 06 39 AM" src="https://user-images.githubusercontent.com/264948/190150224-3bdada6e-2e11-46a6-9f96-fcede95ac177.png">

```
--------
Mapping SourceSet commonMain -> main
** SourceSets: main now includes sources from commonMain **
Added src/commonMain/java as a Kotlin sources for main
Added src/commonMain/kotlin as a Kotlin sources for main
--------
Added src/commonMain/resources as Kotlin resources for main
Added src/commonMain/resources as Java resources for main
--------
** Configurations: main extendsFrom commonMain **
api extendsFrom commonMainApi
implementation extendsFrom commonMainImplementation
compileOnly extendsFrom commonMainCompileOnly
runtimeOnly extendsFrom commonMainRuntimeOnly
apiDependenciesMetadata extendsFrom commonMainApiDependenciesMetadata
implementationDependenciesMetadata extendsFrom commonMainImplementationDependenciesMetadata
compileOnlyDependenciesMetadata extendsFrom commonMainCompileOnlyDependenciesMetadata
runtimeOnlyDependenciesMetadata extendsFrom commonMainRuntimeOnlyDependenciesMetadata
--------
Mapping SourceSet jvmMain -> main
** SourceSets: main now includes sources from jvmMain **
Added src/jvmMain/java as a Kotlin sources for main
Added src/jvmMain/kotlin as a Kotlin sources for main
--------
Added src/jvmMain/resources as Kotlin resources for main
Added src/jvmMain/resources as Java resources for main
--------
** Configurations: main extendsFrom jvmMain **
api extendsFrom jvmMainApi
implementation extendsFrom jvmMainImplementation
compileOnly extendsFrom jvmMainCompileOnly
runtimeOnly extendsFrom jvmMainRuntimeOnly
apiDependenciesMetadata extendsFrom jvmMainApiDependenciesMetadata
implementationDependenciesMetadata extendsFrom jvmMainImplementationDependenciesMetadata
compileOnlyDependenciesMetadata extendsFrom jvmMainCompileOnlyDependenciesMetadata
runtimeOnlyDependenciesMetadata extendsFrom jvmMainRuntimeOnlyDependenciesMetadata
--------
Mapping SourceSet commonTest -> test
** SourceSets: test now includes sources from commonTest **
Added src/commonTest/java as a Kotlin sources for test
Added src/commonTest/kotlin as a Kotlin sources for test
--------
Added src/commonTest/resources as Kotlin resources for test
Added src/commonTest/resources as Java resources for test
--------
```

## `kmp4free=true`
<img width="619" alt="Screen Shot 2022-09-14 at 8 07 03 AM" src="https://user-images.githubusercontent.com/264948/190150222-10118581-0b9f-4e2b-b3ec-631d1f7d350d.png">
```
--------
Mapping SourceSet main -> commonMain
** SourceSets: commonMain now includes sources from main **
Added src/main/java as a Kotlin sources for commonMain
Added src/main/kotlin as a Kotlin sources for commonMain
--------
Added src/main/resources as Kotlin resources for commonMain
--------
** Configurations: commonMain extendsFrom main **
commonMainApi extendsFrom api
commonMainImplementation extendsFrom implementation
commonMainCompileOnly extendsFrom compileOnly
commonMainRuntimeOnly extendsFrom runtimeOnly
commonMainApiDependenciesMetadata extendsFrom apiDependenciesMetadata
commonMainImplementationDependenciesMetadata extendsFrom implementationDependenciesMetadata
commonMainCompileOnlyDependenciesMetadata extendsFrom compileOnlyDependenciesMetadata
commonMainRuntimeOnlyDependenciesMetadata extendsFrom runtimeOnlyDependenciesMetadata
--------
Mapping SourceSet test -> jvmTest
** SourceSets: jvmTest now includes sources from test **
Added src/test/java as a Kotlin sources for jvmTest
Added src/test/kotlin as a Kotlin sources for jvmTest
--------
Added src/test/resources as Kotlin resources for jvmTest
--------
```
